### PR TITLE
Update maven-shade-plugin to resolve Maven Aether Migration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,7 @@
       <plugin>
   		<groupId>org.apache.maven.plugins</groupId>
   		<artifactId>maven-shade-plugin</artifactId>
-  		<version>2.0</version>
+  		<version>2.1</version>
   		<configuration>
   		</configuration>
   		<executions>


### PR DESCRIPTION
Changing the dependency on Aether is incompatible with the old version of maven-shade-plugin and broke this build. See https://cwiki.apache.org/confluence/display/MAVEN/AetherClassNotFound
